### PR TITLE
New warnings and improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         - 3.7
         - 3.8
         - 3.9
+        - '3.10'
 
     name: "🐍 ${{ matrix.python }} • ${{ matrix.runs-on }} • x64 ${{ matrix.args }}"
     runs-on: ${{ matrix.runs-on }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,6 +64,7 @@ repos:
     rev: 'v3.0.0a4'
     hooks:
       - id: pylint
+        additional_dependencies: [flake8]
         # This is a slow hook, so only run this if --hook-stage manual is passed
         stages: [manual]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   Added SCS118 to avoid using `os.mknod` with unsafe file permissions
 -   Added SCS119 to avoid using `os.chmod` with unsafe file permissions (W ^ X for group and others)
 
+### Repository
+
+-   Add Python 3.10 to the list of configurations for testing
+
 ## [1.2.2] - 2022-05-24
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Added SCS112 to avoid using `os.open()` with unsafe permissions
+-   Added SCS113 to avoid using `pickle.load()` and `pickle.loads()`
+-   Added SCS114 to avoid using `marshal.load()` and `marshal.loads()`
+-   Added SCS115 to avoid using `shelve.open()`
+-   Added SCS116 to avoid using `os.mkdir` and `os.makedirs` with unsafe file permissions
+-   Added SCS117 to avoid using `os.mkfifo` with unsafe file permissions
+-   Added SCS118 to avoid using `os.mknod` with unsafe file permissions
+-   Added SCS119 to avoid using `os.chmod` with unsafe file permissions (W ^ X for group and others)
+
 ## [1.2.2] - 2022-05-24
 
 ### Updated

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ flake8 plugin that enforces some secure coding standards.
 | SCS113 | Avoid using `pickle.load()` and `pickle.loads()`                                                              |
 | SCS114 | Avoid using `marshal.load()` and `marshal.loads()`                                                            |
 | SCS115 | Avoid using `shelve.open()`                                                                                   |
+| SCS116 | Avoid using `os.mkdir` and `os.makedirs` with unsafe file permissions                                         |
+| SCS117 | Avoid using `os.mkfifo` with unsafe file permissions                                                          |
+| SCS118 | Avoid using `os.mknod` with unsafe file permissions                                                           |
 
 
 ### Mode-like options

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ flake8 plugin that enforces some secure coding standards.
 | SCS109 | Use of builtin `open` for writing is discouraged in favor of `os.open` to allow for setting file permissions  |
 | SCS110 | Avoid using `os.popen()` as it internally uses `subprocess.Popen` with `shell=True`                           |
 | SCS111 | Use of `shlex.quote()` should be avoided on non-POSIX platforms                                               |
+| SCS113 | Avoid using `pickle.load()` and `pickle.loads()`                                                              |
+| SCS114 | Avoid using `marshal.load()` and `marshal.loads()`                                                            |
+| SCS115 | Avoid using `shelve.open()`                                                                                   |
 
 ## Pre-commit hook
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,16 @@ flake8 plugin that enforces some secure coding standards.
 ### Mode-like options
 
 Mode-like options are configuration options for errors/warnings that relate to some function that accepts a `mode`
-parameter (or similar) that control some file or directory permissions. For those kind of options, the plugin
-understands a variety of values that must be specified as `string`. They will then be parsed into a list of allowed mode
-values:
+parameter (or similar) that control some file or directory permissions. This is typically valid for the followiing warnings:
+
+- SCS116
+- SCS117
+- SCS118
+
+Since these warnings can be quite disruptive, they are turned off by default.
+
+For those kind of options, the plugin understands a variety of values that must be specified as `string`. They will then
+be parsed into a list of allowed mode values:
 
 - Any positive, non-zero (octal or decimal) integer value specifies the maximum value for the mode value
 - A comma-separated list of (octal or decimal) integers indicates the list of allowed mode values

--- a/README.md
+++ b/README.md
@@ -38,11 +38,13 @@ flake8 plugin that enforces some secure coding standards.
 ### Mode-like options
 
 Mode-like options are configuration options for errors/warnings that relate to some function that accepts a `mode`
-parameter (or similar) that control some file or directory permissions. This is typically valid for the followiing warnings:
+parameter (or similar) that control some file or directory permissions. This is typically valid for the followiing
+warnings (corresponding command-line option name in parentheses):
 
-- SCS116
-- SCS117
-- SCS118
+- SCS112 (`os-open-mode`)
+- SCS116 (`os-mkdir-mode`)
+- SCS117 (`os-mkfifo-mode`)
+- SCS118 (`os-mknod-mode`)
 
 Since these warnings can be quite disruptive, they are turned off by default.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ flake8 plugin that enforces some secure coding standards.
 | SCS116 | Avoid using `os.mkdir` and `os.makedirs` with unsafe file permissions                                         |
 | SCS117 | Avoid using `os.mkfifo` with unsafe file permissions                                                          |
 | SCS118 | Avoid using `os.mknod` with unsafe file permissions                                                           |
+| SCS119 | Avoid using `os.chmod` with unsafe file permissions (W ^ X for group and others)                              |
 
 
 ### Mode-like options

--- a/README.md
+++ b/README.md
@@ -25,9 +25,40 @@ flake8 plugin that enforces some secure coding standards.
 | SCS109 | Use of builtin `open` for writing is discouraged in favor of `os.open` to allow for setting file permissions  |
 | SCS110 | Avoid using `os.popen()` as it internally uses `subprocess.Popen` with `shell=True`                           |
 | SCS111 | Use of `shlex.quote()` should be avoided on non-POSIX platforms                                               |
+| SCS112 | Avoid using `os.open()` with unsafe permissions                                                               |
 | SCS113 | Avoid using `pickle.load()` and `pickle.loads()`                                                              |
 | SCS114 | Avoid using `marshal.load()` and `marshal.loads()`                                                            |
 | SCS115 | Avoid using `shelve.open()`                                                                                   |
+
+
+### Mode-like options
+
+Mode-like options are configuration options for errors/warnings that relate to some function that accepts a `mode`
+parameter (or similar) that control some file or directory permissions. For those kind of options, the plugin
+understands a variety of values that must be specified as `string`. They will then be parsed into a list of allowed mode
+values:
+
+- Any positive, non-zero (octal or decimal) integer value specifies the maximum value for the mode value
+- A comma-separated list of (octal or decimal) integers indicates the list of allowed mode values
+- 'y', 'yes', 'true' (case-insensitive) will turn on the warnings using the default value of `0o755`
+- 'n', 'no', 'false' (case-insensitive) will turn off the warnings
+
+Example of values:
+```toml
+    [flake8]
+    os-open-mode = '0'            # check disabled
+    os-open-mode = 'no'           # check disabled
+    os-open-mode = '493'          # all modes from 0 to 493 (=0o755)
+    os-open-mode = '0o755'        # all modes from 0 to 0o755
+    os-open-mode = '0o755,'       # only 0o755 (notice the comma)
+    os-open-mode = '0o644,0o755'  # only 0o644 and 0o755
+```
+
+You can also specify those options directly on the command line:
+
+```sh
+python3 -m flake8 --os-open-mode='0o755'
+```
 
 ## Pre-commit hook
 

--- a/flake8_secure_coding_standard.py
+++ b/flake8_secure_coding_standard.py
@@ -216,13 +216,19 @@ def _is_builtin_open_for_writing(node: ast.Call) -> bool:
 
 def _get_mode_arg(node, args_idx):
     mode = None
-    if len(node.args) > args_idx and isinstance(node.args[args_idx], ast_Constant):
-        mode = node.args[args_idx].value
+    node_intern = None
+    if len(node.args) > args_idx:
+        node_intern = node.args[args_idx]
     elif node.keywords:
         for keyword in node.keywords:
-            if keyword.arg == 'mode' and isinstance(keyword.value, ast_Constant):
-                mode = keyword.value.value
+            if keyword.arg == 'mode':
+                node_intern = keyword.value
                 break
+    if node_intern:
+        if isinstance(node_intern, ast_Constant):
+            mode = node_intern.value
+        elif isinstance(node_intern, ast.Num):  # pragma: no cover
+            mode = node_intern.n
     return mode
 
 

--- a/flake8_secure_coding_standard.py
+++ b/flake8_secure_coding_standard.py
@@ -16,8 +16,7 @@
 """Main file for the flake8_secure_coding_standard plugin."""
 
 import ast
-import operator
-import optparse
+import optparse  # pylint: disable=deprecated-module
 import platform
 import stat
 import sys
@@ -134,7 +133,8 @@ def _read_octal_mode_option(name, value, default):
         raise ValueError(f'Invalid value for `{name}`: {value}!')
 
 
-def octal_mode_option_callback(option, opt, value, parser):
+def octal_mode_option_callback(option, _, value, parser):
+    """Octal mode option callback."""
     setattr(parser.values, f'{option.dest}', _read_octal_mode_option(option.dest, value, _DEFAULT_MAX_MODE))
 
 
@@ -339,8 +339,6 @@ def _is_yaml_unsafe_call(node: ast.Call) -> bool:
 # ==============================================================================
 
 
-
-
 class Visitor(ast.NodeVisitor):
     """AST visitor class for the plugin."""
 
@@ -362,6 +360,7 @@ class Visitor(ast.NodeVisitor):
 
     @classmethod
     def format_mode_msg(cls, msg_id):
+        """Format a mode message."""
         return msg_id.format(getattr(cls, f'os_{cls.mode_msg_map[msg_id]}_modes_msg_arg'))
 
     def __init__(self) -> None:
@@ -369,7 +368,7 @@ class Visitor(ast.NodeVisitor):
         self.errors: List[Tuple[int, int, str]] = []
         self._from_imports: Dict[str, str] = {}
 
-    def visit_Call(self, node: ast.Call) -> None:
+    def visit_Call(self, node: ast.Call) -> None:  # pylint: disable=too-many-branches
         """Visitor method called for ast.Call nodes."""
         if _is_pdb_call(node):
             self.errors.append((node.lineno, node.col_offset, SCS107))
@@ -522,6 +521,7 @@ class Plugin:  # pylint: disable=R0903
 
     @classmethod
     def add_options(cls, option_manager: flake8.options.manager.OptionManager) -> None:
+        """Add command line options."""
         option_manager.add_option(
             "--os-mkdir-mode",
             action='callback',
@@ -565,6 +565,8 @@ class Plugin:  # pylint: disable=R0903
 
     @classmethod
     def parse_options(cls, options: optparse.Values) -> None:
+        """Parse command line options."""
+
         def _set_mode_option(name, modes):
             if isinstance(modes, int) and modes > 0:
                 setattr(Visitor, f'os_{name}_modes_allowed', list(range(0, modes + 1)))

--- a/flake8_secure_coding_standard.py
+++ b/flake8_secure_coding_standard.py
@@ -36,7 +36,7 @@ else:  # pragma: no cover
 _use_optparse = tuple(int(s) for s in importlib_metadata.version('flake8').split('.')) < (3, 8, 0)
 
 if _use_optparse:  # pragma: no cover
-    import optparse  # pylint: disable=deprecated-module
+    import optparse  # noqa: F401 pylint: disable=deprecated-module, unused-import
 else:
     import argparse
 
@@ -682,6 +682,8 @@ class Plugin:  # pylint: disable=R0903
         """Add command line options using argparse."""
 
         class OctalModeAction(argparse.Action):
+            """Action class for octal mode options."""
+
             def __call__(self, parser, namespace, values, option_string=None):
                 setattr(namespace, self.dest, _read_octal_mode_option(self.dest, values, _DEFAULT_MAX_MODE))
 

--- a/flake8_secure_coding_standard.py
+++ b/flake8_secure_coding_standard.py
@@ -16,6 +16,7 @@
 """Main file for the flake8_secure_coding_standard plugin."""
 
 import ast
+import operator
 import optparse  # pylint: disable=deprecated-module
 import platform
 import stat
@@ -70,6 +71,7 @@ SCS115 = 'Avoid using `shelve.open()`'
 SCS116 = 'Avoid using `os.mkdir` and `os.makedirs` with unsafe file permissions (should be {})'
 SCS117 = 'Avoid using `os.mkfifo` with unsafe file permissions (should be {})'
 SCS118 = 'Avoid using `os.mknod` with unsafe file permissions (should be {})'
+SCS119 = 'Avoid using `os.chmod` with unsafe file permissions (W ^ X for group and others)'
 
 
 # ==============================================================================
@@ -338,6 +340,93 @@ def _is_yaml_unsafe_call(node: ast.Call) -> bool:
 
 # ==============================================================================
 
+_unop = {ast.USub: operator.neg, ast.Not: operator.not_, ast.Invert: operator.inv}
+_binop = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv,
+    ast.Mod: operator.mod,
+    ast.BitXor: operator.xor,
+    ast.BitOr: operator.or_,
+    ast.BitAnd: operator.and_,
+}
+_chmod_known_mode_values = (
+    'S_ISUID',
+    'S_ISGID',
+    'S_ENFMT',
+    'S_ISVTX',
+    'S_IREAD',
+    'S_IWRITE',
+    'S_IEXEC',
+    'S_IRWXU',
+    'S_IRUSR',
+    'S_IWUSR',
+    'S_IXUSR',
+    'S_IRWXG',
+    'S_IRGRP',
+    'S_IWGRP',
+    'S_IXGRP',
+    'S_IRWXO',
+    'S_IROTH',
+    'S_IWOTH',
+    'S_IXOTH',
+)
+
+
+def _chmod_get_mode(node):
+    """
+    Extract the mode constant of a node.
+
+    Args:
+        node: an AST node
+
+    Raises:
+        ValueError: if a node is encountered that cannot be processed
+    """
+    if isinstance(node, ast.Name) and node.id in _chmod_known_mode_values:
+        return getattr(stat, node.id)
+    if (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.attr in _chmod_known_mode_values
+        and node.value.id == 'stat'
+    ):
+        return getattr(stat, node.attr)
+    if isinstance(node, ast.UnaryOp):
+        return _unop[type(node.op)](_chmod_get_mode(node.operand))
+    if isinstance(node, ast.BinOp):
+        return _binop[type(node.op)](_chmod_get_mode(node.left), _chmod_get_mode(node.right))
+
+    raise ValueError(f'Do not know how to process node: {ast.dump(node)}')
+
+
+def _chmod_has_wx_for_go(node):
+    if platform.system() == 'Windows':
+        # On Windows, only stat.S_IREAD and stat.S_IWRITE can be used, all other bits are ignored
+        return False
+
+    try:
+        modes = None
+        if len(node.args) > 1:
+            modes = _chmod_get_mode(node.args[1])
+        elif node.keywords:
+            for keyword in node.keywords:
+                if keyword.arg == 'mode':
+                    modes = _chmod_get_mode(keyword.value)
+                    break
+    except ValueError:
+        return False
+    else:
+        if modes is None:
+            # NB: this would be from invalid code such as `os.chmod("file.txt")`
+            raise RuntimeError('Unable to extract `mode` argument from function call!')
+        return bool(modes & (stat.S_IWGRP | stat.S_IXGRP | stat.S_IWOTH | stat.S_IXOTH))
+
+
+# ==============================================================================
+
 
 class Visitor(ast.NodeVisitor):
     """AST visitor class for the plugin."""
@@ -404,6 +493,8 @@ class Visitor(ast.NodeVisitor):
             self.errors.append((node.lineno, node.col_offset, SCS114))
         elif _is_function_call(node, module='shelve', function='open'):
             self.errors.append((node.lineno, node.col_offset, SCS115))
+        elif _is_function_call(node, module='os', function='chmod') and _chmod_has_wx_for_go(node):
+            self.errors.append((node.lineno, node.col_offset, SCS119))
         elif _is_unix():
             if (
                 _is_function_call(node, module='os', function=('mkdir', 'makedirs'))

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 
 [options]

--- a/tests/marshal_load_test.py
+++ b/tests/marshal_load_test.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Damien Nguyen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+
+import pytest
+
+import flake8_secure_coding_standard as flake8_scs
+
+
+def results(s):
+    return {'{}:{}: {}'.format(*r) for r in flake8_scs.Plugin(ast.parse(s)).run()}
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        '',
+        'marshal.dump(data, "file.txt")',
+        'marshal.dumps(data)',
+    ),
+)
+def test_ok(s):
+    assert results(s) == set()
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        'marshal.load("file.txt")',
+        r'marshal.loads(b"\xe9\x01\x00\x00\x00")',
+        'marshal.loads(data)',
+        'from marshal import load',
+        'from marshal import loads',
+        'from marshal import dump, load',
+    ),
+)
+def test_not_ok(s):
+    assert results(s) == {'1:0: ' + flake8_scs.SCS114}

--- a/tests/os_chmod_test.py
+++ b/tests/os_chmod_test.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Damien Nguyen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+import stat
+
+import pytest
+
+import flake8_secure_coding_standard as flake8_scs
+
+
+def results(s):
+    return {'{}:{}: {}'.format(*r) for r in flake8_scs.Plugin(ast.parse(s)).run()}
+
+
+# ==============================================================================
+
+
+@pytest.mark.parametrize(
+    's, expected',
+    (
+        ('S_IREAD', stat.S_IREAD),
+        ('stat.S_IREAD', stat.S_IREAD),
+        ('S_IREAD | S_IWRITE', stat.S_IREAD | stat.S_IWRITE),
+        ('stat.S_IREAD | stat.S_IWRITE', stat.S_IREAD | stat.S_IWRITE),
+        ('stat.S_IREAD | stat.S_IWRITE | S_IXUSR', stat.S_IREAD | stat.S_IWRITE | stat.S_IXUSR),
+    ),
+)
+def test_chmod_get_mode(s, expected):
+    node = ast.parse(s).body[0].value
+    assert flake8_scs._chmod_get_mode(node) == expected
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        'stat.ST_MODE',
+        'bla.S_IREAD',
+    ),
+)
+def test_chmod_get_mode_invalid(s):
+    node = ast.parse(s).body[0].value
+    with pytest.raises(ValueError):
+        flake8_scs._chmod_get_mode(node)
+
+
+@pytest.mark.parametrize(
+    's, expected',
+    (
+        ('-stat.S_IREAD', -stat.S_IREAD),
+        ('~stat.S_IREAD', ~stat.S_IREAD),
+        ('not stat.S_IREAD', not stat.S_IREAD),
+    ),
+)
+def test_chmod_get_mode_unop(s, expected):
+    node = ast.parse(s).body[0].value
+    assert flake8_scs._chmod_get_mode(node) == expected
+
+
+@pytest.mark.parametrize(
+    's, expected',
+    (
+        ('stat.S_IREAD + stat.S_IWRITE', stat.S_IREAD + stat.S_IWRITE),
+        ('stat.S_IREAD - stat.S_IWRITE', stat.S_IREAD - stat.S_IWRITE),
+        ('stat.S_IREAD * stat.S_IWRITE', stat.S_IREAD * stat.S_IWRITE),
+        ('stat.S_IREAD / stat.S_IWRITE', stat.S_IREAD / stat.S_IWRITE),
+        ('stat.S_IREAD // stat.S_IWRITE', stat.S_IREAD // stat.S_IWRITE),
+        ('stat.S_IREAD % stat.S_IWRITE', stat.S_IREAD % stat.S_IWRITE),
+        ('stat.S_IREAD ^ stat.S_IWRITE', stat.S_IREAD ^ stat.S_IWRITE),
+        ('stat.S_IREAD | stat.S_IWRITE', stat.S_IREAD | stat.S_IWRITE),
+        ('stat.S_IREAD & stat.S_IWRITE', stat.S_IREAD & stat.S_IWRITE),
+    ),
+)
+def test_chmod_get_mode_binop(s, expected):
+    node = ast.parse(s).body[0].value
+    assert flake8_scs._chmod_get_mode(node) == expected
+
+
+@pytest.mark.parametrize(
+    'platform, enabled_platform',
+    (
+        ('Linux', True),
+        ('Darwin', True),
+        ('Java', True),
+        ('Windows', False),
+    ),
+)
+@pytest.mark.parametrize('fname', ('"file.txt"', 'fname'))
+@pytest.mark.parametrize('arg_type', ('', 'mode='), ids=('arg', 'keyword'))
+@pytest.mark.parametrize(
+    'forbidden',
+    (
+        'S_IRGRP',  # NB: not actually a forbidden value, only for testing...
+        'S_IRWXG',
+        'S_IWGRP',
+        'S_IXGRP',
+        'S_IRWXO',
+        'S_IWOTH',
+        'S_IXOTH',
+    ),
+)
+@pytest.mark.parametrize(
+    's',
+    (
+        '',
+        'S_IREAD',
+        'S_IREAD | S_IWRITE',
+        'S_IRUSR | S_IWUSR | S_IXUSR',
+    ),
+    ids=lambda s: s if s else '<empty>',
+)
+def test_chmod(mocker, platform, enabled_platform, fname, arg_type, forbidden, s):
+    mocker.patch('platform.system', lambda: platform)
+
+    if s:
+        code = f'os.chmod({fname}, {arg_type}{s} | {forbidden}) #@'
+    else:
+        code = f'os.chmod({fname}, {arg_type} {forbidden}) #@'
+
+    print(code)
+    flake8_warnings = results(code)
+    if enabled_platform and forbidden != 'S_IRGRP':
+        assert flake8_warnings == {'1:0: ' + flake8_scs.SCS119}
+    else:
+        assert flake8_warnings == set()
+
+
+@pytest.mark.parametrize('platform', ('Linux', 'Darwin', 'Java', 'Windows'))
+@pytest.mark.parametrize(
+    's',
+    (
+        'os.chmod("file.txt", stat.ST_MODE)',
+        'os.chmod("file.txt", other.S_IRWXO)',
+        'os.chmod("file.txt", mode)',
+        'os.chmod("file.txt", mode=mode)',
+    ),
+)
+def test_chmod_no_warning(mocker, platform, s):
+    mocker.patch('platform.system', lambda: platform)
+
+    assert results(s) == set()
+
+
+@pytest.mark.parametrize(
+    'platform, enabled_platform',
+    (
+        ('Linux', True),
+        ('Darwin', True),
+        ('Java', True),
+        ('Windows', False),
+    ),
+)
+@pytest.mark.parametrize('s', ('os.chmod("file")',))
+def test_chmod_invalid_raise(mocker, platform, enabled_platform, s):
+    mocker.patch('platform.system', lambda: platform)
+
+    if enabled_platform:
+        with pytest.raises(RuntimeError):
+            results(s)
+    else:
+        assert results(s) == set()

--- a/tests/os_mkdir_mkfifo_mknod_test.py
+++ b/tests/os_mkdir_mkfifo_mknod_test.py
@@ -144,7 +144,7 @@ def test_os_function_call(mocker, platform, enabled_platform, function, option, 
     mocker.patch('platform.system', lambda: platform)
 
     flake8_warnings = results(s)
-    if enabled_platform and option:
+    if enabled_platform and option == 'True':
         assert flake8_warnings == {'1:0: ' + flake8_scs.Visitor.format_mode_msg(_msg_map[function])}
     else:
         assert flake8_warnings == set()

--- a/tests/os_mkdir_mkfifo_mknod_test.py
+++ b/tests/os_mkdir_mkfifo_mknod_test.py
@@ -106,6 +106,8 @@ def test_os_function_ok(mocker, platform, function, option, s):
     mocker.patch('platform.system', lambda: platform)
 
     assert results(s) == set()
+
+
 @pytest.mark.parametrize(
     'platform, enabled_platform',
     (
@@ -123,9 +125,7 @@ def test_os_function_ok(mocker, platform, function, option, s):
     'function, s', ((function, s) for function, tests in _os_function_strings.items() for s in tests)
 )
 def test_os_function_call(mocker, platform, enabled_platform, function, option, s):
-    _msg_map = {'mkdir': flake8_scs.SCS116,
-                'mkfifo': flake8_scs.SCS117,
-                'mknod': flake8_scs.SCS118}
+    _msg_map = {'mkdir': flake8_scs.SCS116, 'mkfifo': flake8_scs.SCS117, 'mknod': flake8_scs.SCS118}
 
     flake8_scs.Plugin.parse_options(
         optparse.Values(

--- a/tests/os_mkdir_mkfifo_mknod_test.py
+++ b/tests/os_mkdir_mkfifo_mknod_test.py
@@ -20,6 +20,8 @@ import pytest
 
 import flake8_secure_coding_standard as flake8_scs
 
+# ==============================================================================
+
 _os_function_strings = {
     'mkdir': (
         'os.mkdir("/tmp/test", 0o777)',
@@ -46,8 +48,14 @@ _os_function_strings = {
 }
 
 
+# ------------------------------------------------------------------------------
+
+
 def results(s):
     return {'{}:{}: {}'.format(*r) for r in flake8_scs.Plugin(ast.parse(s)).run()}
+
+
+# ==============================================================================
 
 
 @pytest.mark.parametrize(
@@ -87,17 +95,21 @@ def results(s):
     ),
 )
 def test_os_function_ok(mocker, platform, function, option, s):
+    os_mkdir_mode = option if function == 'mkdir' else 'False'
+    os_mkfifo_mode = option if function == 'mkfifo' else 'False'
+    os_mknod_mode = option if function == 'mknod' else 'False'
+
     flake8_scs.Plugin.parse_options(
         optparse.Values(
             {
                 'os_mkdir_mode': flake8_scs._read_octal_mode_option(
-                    'os_mkdir_mode', option, flake8_scs._DEFAULT_MAX_MODE
+                    'os_mkdir_mode', os_mkdir_mode, flake8_scs._DEFAULT_MAX_MODE
                 ),
                 'os_mkfifo_mode': flake8_scs._read_octal_mode_option(
-                    'os_mkfifo_mode', option, flake8_scs._DEFAULT_MAX_MODE
+                    'os_mkfifo_mode', os_mkfifo_mode, flake8_scs._DEFAULT_MAX_MODE
                 ),
                 'os_mknod_mode': flake8_scs._read_octal_mode_option(
-                    'os_mknod_mode', option, flake8_scs._DEFAULT_MAX_MODE
+                    'os_mknod_mode', os_mknod_mode, flake8_scs._DEFAULT_MAX_MODE
                 ),
                 'os_open_mode': False,
             }

--- a/tests/os_mkdir_mkfifo_mknod_test.py
+++ b/tests/os_mkdir_mkfifo_mknod_test.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Damien Nguyen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+import optparse
+
+import pytest
+
+import flake8_secure_coding_standard as flake8_scs
+
+_os_function_strings = {
+    'mkdir': (
+        'os.mkdir("/tmp/test", 0o777)',
+        'os.mkdir(dir_name, 0o777)',
+        'os.mkdir("/tmp/test", mode=0o777)',
+        'os.mkdir(dir_name, mode=0o777)',
+        'os.makedirs("/tmp/test/utils", 0o777)',
+        'os.makedirs(dir_name, 0o777)',
+        'os.makedirs("/tmp/test/utils", mode=0o777)',
+        'os.makedirs(dir_name, mode=0o777)',
+    ),
+    'mkfifo': (
+        'os.mkfifo("/tmp/test.log", 0o777)',
+        'os.mkfifo(dir_name, 0o777)',
+        'os.mkfifo("/tmp/test.log", mode=0o777)',
+        'os.mkfifo(dir_name, mode=0o777)',
+    ),
+    'mknod': (
+        'os.mknod("/tmp/test", 0o777)',
+        'os.mknod(dir_name, 0o777)',
+        'os.mknod("/tmp/test", mode=0o777)',
+        'os.mknod(dir_name, mode=0o777)',
+    ),
+}
+
+
+def results(s):
+    return {'{}:{}: {}'.format(*r) for r in flake8_scs.Plugin(ast.parse(s)).run()}
+
+
+@pytest.mark.parametrize(
+    'platform',
+    ('Linux', 'Darwin', 'Java', 'Windows'),
+)
+@pytest.mark.parametrize('function', ('mkdir', 'mkfifo', 'mknod'))
+@pytest.mark.parametrize(
+    'option',
+    ('False', 'True'),
+)
+@pytest.mark.parametrize(
+    's',
+    (
+        # mkdir
+        'os.mkdir("/tmp/test")',
+        'os.mkdir(dir_name)',
+        'os.mkdir("/tmp/test", 0o644)',
+        'os.mkdir(dir_name, 0o644)',
+        'os.mkdir("/tmp/test", mode=mode)',
+        'os.mkdir(dir_name, mode=mode)',
+        # makedirs
+        'os.makedirs("/tmp/test/utils")',
+        'os.makedirs(dir_name)',
+        'os.makedirs("/tmp/test/utils", 0o644)',
+        'os.makedirs(dir_name, 0o644)',
+        'os.makedirs("/tmp/test/utils", mode=mode)',
+        'os.makedirs(dir_name, mode=mode)',
+        # mkfifo
+        'os.mkfifo("/tmp/test/utils")',
+        'os.mkfifo("/tmp/test/utils", 0o644)',
+        'os.mkfifo("/tmp/test/utils", mode=mode)',
+        # mknod
+        'os.mknod(dir_name)',
+        'os.mknod(dir_name, 0o644)',
+        'os.mknod(dir_name, mode=mode)',
+    ),
+)
+def test_os_function_ok(mocker, platform, function, option, s):
+    flake8_scs.Plugin.parse_options(
+        optparse.Values(
+            {
+                'os_mkdir_mode': flake8_scs._read_octal_mode_option(
+                    'os_mkdir_mode', option, flake8_scs._DEFAULT_MAX_MODE
+                ),
+                'os_mkfifo_mode': flake8_scs._read_octal_mode_option(
+                    'os_mkfifo_mode', option, flake8_scs._DEFAULT_MAX_MODE
+                ),
+                'os_mknod_mode': flake8_scs._read_octal_mode_option(
+                    'os_mknod_mode', option, flake8_scs._DEFAULT_MAX_MODE
+                ),
+                'os_open_mode': False,
+            }
+        )
+    )
+    mocker.patch('platform.system', lambda: platform)
+
+    assert results(s) == set()
+@pytest.mark.parametrize(
+    'platform, enabled_platform',
+    (
+        ('Linux', True),
+        ('Darwin', True),
+        ('Java', False),
+        ('Windows', False),
+    ),
+)
+@pytest.mark.parametrize(
+    'option',
+    (False, True),
+)
+@pytest.mark.parametrize(
+    'function, s', ((function, s) for function, tests in _os_function_strings.items() for s in tests)
+)
+def test_os_function_call(mocker, platform, enabled_platform, function, option, s):
+    _msg_map = {'mkdir': flake8_scs.SCS116,
+                'mkfifo': flake8_scs.SCS117,
+                'mknod': flake8_scs.SCS118}
+
+    flake8_scs.Plugin.parse_options(
+        optparse.Values(
+            {
+                'os_mkdir_mode': flake8_scs._read_octal_mode_option(
+                    'os_mkdir_mode', str(option), flake8_scs._DEFAULT_MAX_MODE
+                ),
+                'os_mkfifo_mode': flake8_scs._read_octal_mode_option(
+                    'os_mkfifo_mode', str(option), flake8_scs._DEFAULT_MAX_MODE
+                ),
+                'os_mknod_mode': flake8_scs._read_octal_mode_option(
+                    'os_mknod_mode', str(option), flake8_scs._DEFAULT_MAX_MODE
+                ),
+                'os_open_mode': False,
+            }
+        )
+    )
+    mocker.patch('platform.system', lambda: platform)
+
+    flake8_warnings = results(s)
+    if enabled_platform and option:
+        assert flake8_warnings == {'1:0: ' + flake8_scs.Visitor.format_mode_msg(_msg_map[function])}
+    else:
+        assert flake8_warnings == set()

--- a/tests/os_open_test.py
+++ b/tests/os_open_test.py
@@ -27,6 +27,7 @@ def results(s):
 
 # ==============================================================================
 
+
 def configure_plugin(arg):
     flake8_scs.Plugin.parse_options(
         optparse.Values(
@@ -41,6 +42,7 @@ def configure_plugin(arg):
 
 
 # ==============================================================================
+
 
 @pytest.mark.parametrize(
     'arg',
@@ -133,7 +135,9 @@ def test_os_open_call_default_modes(mode, arg, expected_warning):
     else:
         assert flake8_warnings == set()
 
+
 # ------------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize('mode', range(0o750, 0o761), ids=lambda arg: oct(arg))
 @pytest.mark.parametrize(
@@ -161,7 +165,9 @@ def test_os_open_call(mode, call_mode, arg, expected_warning):
     else:
         assert flake8_warnings == set()
 
+
 # ==========================================================================
+
 
 @pytest.mark.parametrize('mode', range(0o756, 0o777 + 1), ids=lambda arg: oct(arg))
 @pytest.mark.parametrize(
@@ -188,7 +194,9 @@ def test_os_open_with_default_modes(mode, call_mode, arg, expected_warning):
     else:
         assert flake8_warnings == set()
 
+
 # --------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize('mode', range(0o750, 0o761), ids=lambda arg: oct(arg))
 @pytest.mark.parametrize(

--- a/tests/os_open_test.py
+++ b/tests/os_open_test.py
@@ -1,0 +1,208 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Damien Nguyen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+import optparse
+
+import pytest
+
+import flake8_secure_coding_standard as flake8_scs
+
+
+def results(s):
+    return {'{}:{}: {}'.format(*r) for r in flake8_scs.Plugin(ast.parse(s)).run()}
+
+
+# ==============================================================================
+
+def configure_plugin(arg):
+    flake8_scs.Plugin.parse_options(
+        optparse.Values(
+            {
+                'os_mkdir_mode': False,
+                'os_mkfifo_mode': False,
+                'os_mknod_mode': False,
+                'os_open_mode': flake8_scs._read_octal_mode_option('os_open_mode', arg, flake8_scs._DEFAULT_MAX_MODE),
+            }
+        )
+    )
+
+
+# ==============================================================================
+
+@pytest.mark.parametrize(
+    'arg',
+    ('No', 'True', '0o644', '0o644,'),
+)
+@pytest.mark.parametrize(
+    's',
+    (
+        'os.open("file.txt")',
+        'os.open("file.txt", flags, mode)',
+        'os.open("file.txt", os.O_RDONLY)',
+        'os.open("file.txt", os.O_RDONLY, mode)',
+        'os.open("file.txt", os.O_RDONLY, 0o644)',
+        'os.open("file.txt", os.O_RDONLY | os.O_NOFOLLOW)',
+        'os.open("file.txt", os.O_RDONLY | os.O_NOFOLLOW, mode)',
+        'os.open("file.txt", os.O_RDONLY | os.O_NOFOLLOW, 0o644)',
+        'os.open("file.txt", os.O_RDONLY, mode=mode)',
+        'os.open("file.txt", os.O_RDONLY, mode=0o644)',
+        'os.open("file.txt", os.O_RDONLY | os.O_NOFOLLOW, mode=mode)',
+        'os.open("file.txt", os.O_RDONLY | os.O_NOFOLLOW, mode=0o644)',
+        'bla.open("file.txt")',
+        'bla.open("file.txt", os.O_RDONLY)',
+        'bla.open("file.txt", flags=os.O_RDONLY)',
+        'bla.open("file.txt", os.O_RDONLY, mode)',
+        'bla.open("file.txt", os.O_RDONLY, 0o644)',
+        'bla.open("file.txt", os.O_RDONLY, 0o777)',
+        'bla.open("file.txt", os.O_RDONLY | os.O_NOFOLLOW)',
+        'bla.open("file.txt", os.O_RDONLY | os.O_NOFOLLOW, mode)',
+        'bla.open("file.txt", os.O_RDONLY | os.O_NOFOLLOW, 0o644)',
+        'bla.open("file.txt", os.O_RDONLY | os.O_NOFOLLOW, 0o777)',
+        'bla.open("file.txt", os.O_RDONLY, mode=mode)',
+        'bla.open("file.txt", os.O_RDONLY, mode=0o644)',
+        'bla.open("file.txt", os.O_RDONLY, mode=0o777)',
+        'bla.open("file.txt", os.O_RDONLY | os.O_NOFOLLOW)',
+        'bla.open("file.txt", os.O_RDONLY | os.O_NOFOLLOW, mode=mode)',
+        'bla.open("file.txt", os.O_RDONLY | os.O_NOFOLLOW, mode=0o644)',
+        'bla.open("file.txt", os.O_RDONLY | os.O_NOFOLLOW, mode=0o777)',
+        'with os.open("file.txt") as fd: fd.read()',
+        'with os.open("file.txt", flags, mode) as fd: fd.read()',
+        'with os.open("file.txt", os.O_RDONLY) as fd: fd.read()',
+        'with os.open("file.txt", os.O_RDONLY, mode) as fd: fd.read()',
+        'with os.open("file.txt", os.O_RDONLY, 0o644) as fd: fd.read()',
+        'with os.open("file.txt", os.O_RDONLY | os.O_NOFOLLOW) as fd: fd.read()',
+        'with os.open("file.txt", os.O_RDONLY | os.O_NOFOLLOW, mode) as fd: fd.read()',
+        'with os.open("file.txt", os.O_RDONLY | os.O_NOFOLLOW, 0o644) as fd: fd.read()',
+        'with os.open("file.txt", flags=flags, mode=mode) as fd: fd.read()',
+        'with os.open("file.txt", flags=os.O_RDONLY, mode=mode) as fd: fd.read()',
+        'with os.open("file.txt", flags=os.O_RDONLY, mode=0o644) as fd: fd.read()',
+        'with os.open("file.txt", flags=os.O_RDONLY | os.O_NOFOLLOW, mode=mode) as fd: fd.read()',
+        'with os.open("file.txt", flags=os.O_RDONLY | os.O_NOFOLLOW, mode=0o644) as fd: fd.read()',
+        'with bla.open("file.txt") as fd: fd.read()',
+        'with bla.open("file.txt", os.O_RDONLY) as fd: fd.read()',
+        'with bla.open("file.txt", os.O_RDONLY, mode) as fd: fd.read()',
+        'with bla.open("file.txt", os.O_RDONLY, 0o644) as fd: fd.read()',
+        'with bla.open("file.txt", os.O_RDONLY, 0o777) as fd: fd.read()',
+        'with bla.open("file.txt", os.O_RDONLY | os.O_NOFOLLOW) as fd: fd.read()',
+        'with bla.open("file.txt", os.O_RDONLY | os.O_NOFOLLOW, mode) as fd: fd.read()',
+        'with bla.open("file.txt", os.O_RDONLY | os.O_NOFOLLOW, 0o644) as fd: fd.read()',
+        'with bla.open("file.txt", os.O_RDONLY | os.O_NOFOLLOW, 0o777) as fd: fd.read()',
+        'with bla.open("file.txt", flags=os.O_RDONLY) as fd: fd.read()',
+        'with bla.open("file.txt", flags=os.O_RDONLY, mode=mode) as fd: fd.read()',
+        'with bla.open("file.txt", flags=os.O_RDONLY, mode=0o644) as fd: fd.read()',
+        'with bla.open("file.txt", flags=os.O_RDONLY, mode=0o777) as fd: fd.read()',
+        'with bla.open("file.txt", flags=os.O_RDONLY | os.O_NOFOLLOW, mode=mode) as fd: fd.read()',
+        'with bla.open("file.txt", flags=os.O_RDONLY | os.O_NOFOLLOW, mode=0o644) as fd: fd.read()',
+        'with bla.open("file.txt", flags=os.O_RDONLY | os.O_NOFOLLOW, mode=0o777) as fd: fd.read()',
+    ),
+)
+def test_ok(s, arg):
+    configure_plugin(arg)
+    assert results(s) == set()
+
+
+# ==============================================================================
+
+
+@pytest.mark.parametrize('mode', range(0o756, 0o777 + 1), ids=lambda arg: oct(arg))
+@pytest.mark.parametrize(
+    'arg, expected_warning',
+    (
+        ('False', False),
+        ('True', True),
+    ),
+)
+def test_os_open_call_default_modes(mode, arg, expected_warning):
+    configure_plugin(arg)
+    flake8_warnings = results(f'os.open("file.txt", os.O_WRONLY, 0o{mode:o})')
+    if expected_warning:
+        assert flake8_warnings == {'1:0: ' + flake8_scs.Visitor.format_mode_msg(flake8_scs.SCS112)}
+    else:
+        assert flake8_warnings == set()
+
+# ------------------------------------------------------------------------------
+
+@pytest.mark.parametrize('mode', range(0o750, 0o761), ids=lambda arg: oct(arg))
+@pytest.mark.parametrize(
+    'call_mode',
+    (
+        'os.open("file.txt", os.O_WRONLY, 0o{:o})',
+        'os.open("file.txt", flags=os.O_WRONLY, mode=0o{:o})',
+    ),
+    ids=('args', 'keyword'),
+)
+@pytest.mark.parametrize(
+    'arg, expected_warning',
+    (
+        ('False', False),
+        ('0o755,', True),
+    ),
+    ids=('False-False', '[0o755]-True'),
+)
+def test_os_open_call(mode, call_mode, arg, expected_warning):
+    configure_plugin(arg)
+    flake8_warnings = results(call_mode.format(mode))
+
+    if expected_warning and mode != 0o755:
+        assert flake8_warnings == {'1:0: ' + flake8_scs.Visitor.format_mode_msg(flake8_scs.SCS112)}
+    else:
+        assert flake8_warnings == set()
+
+# ==========================================================================
+
+@pytest.mark.parametrize('mode', range(0o756, 0o777 + 1), ids=lambda arg: oct(arg))
+@pytest.mark.parametrize(
+    'call_mode',
+    (
+        'with os.open("file.txt", os.O_WRONLY, 0o{:o}) as fd: fd.read()',
+        'with os.open("file.txt", flags=os.O_WRONLY, mode=0o{:o}) as fd: fd.read()',
+    ),
+    ids=('args', 'keyword'),
+)
+@pytest.mark.parametrize(
+    'arg, expected_warning',
+    (
+        ('False', False),
+        ('True', True),
+    ),
+)
+def test_os_open_with_default_modes(mode, call_mode, arg, expected_warning):
+    configure_plugin(arg)
+    flake8_warnings = results(call_mode.format(mode))
+
+    if expected_warning:
+        assert flake8_warnings == {'1:0: ' + flake8_scs.Visitor.format_mode_msg(flake8_scs.SCS112)}
+    else:
+        assert flake8_warnings == set()
+
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize('mode', range(0o750, 0o761), ids=lambda arg: oct(arg))
+@pytest.mark.parametrize(
+    'arg, expected_warning',
+    (
+        ('False', False),
+        ('0o755,', True),
+    ),
+)
+def test_os_open_with(mode, arg, expected_warning):
+    configure_plugin(arg)
+    flake8_warnings = results(f'with os.open("file.txt", os.O_WRONLY, 0o{mode:o}) as fd: fd.read()')
+
+    if expected_warning and mode != 0o755:
+        assert flake8_warnings == {'1:0: ' + flake8_scs.Visitor.format_mode_msg(flake8_scs.SCS112)}
+    else:
+        assert flake8_warnings == set()

--- a/tests/os_open_test.py
+++ b/tests/os_open_test.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import ast
-import optparse
+from collections import namedtuple
 
 import pytest
 
@@ -29,16 +29,20 @@ def results(s):
 
 
 def configure_plugin(arg):
+    mode = flake8_scs._read_octal_mode_option('os_open_mode', arg, flake8_scs._DEFAULT_MAX_MODE)
+    OptionValue = namedtuple(
+        'options_values',
+        field_names=('os_mkdir_mode', 'os_mkfifo_mode', 'os_mknod_mode', 'os_open_mode'),
+    )
     flake8_scs.Plugin.parse_options(
-        optparse.Values(
-            {
-                'os_mkdir_mode': False,
-                'os_mkfifo_mode': False,
-                'os_mknod_mode': False,
-                'os_open_mode': flake8_scs._read_octal_mode_option('os_open_mode', arg, flake8_scs._DEFAULT_MAX_MODE),
-            }
+        OptionValue(
+            False,
+            False,
+            False,
+            mode,
         )
     )
+    assert flake8_scs.Visitor.os_open_modes_allowed == [] if mode is None else mode
 
 
 # ==============================================================================

--- a/tests/pickle_load_test.py
+++ b/tests/pickle_load_test.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Damien Nguyen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+
+import pytest
+
+import flake8_secure_coding_standard as flake8_scs
+
+
+def results(s):
+    return {'{}:{}: {}'.format(*r) for r in flake8_scs.Plugin(ast.parse(s)).run()}
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        '',
+        'pickle.dump(data, "file.txt")',
+        'pickle.dumps(data)',
+    ),
+)
+def test_ok(s):
+    assert results(s) == set()
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        'pickle.load("file.txt")',
+        r'pickle.loads(b"\x80\x04K\x01.")',
+        'pickle.loads(data)',
+        'from pickle import load',
+        'from pickle import loads',
+        'from pickle import dump, load',
+    ),
+)
+def test_not_ok(s):
+    assert results(s) == {'1:0: ' + flake8_scs.SCS113}

--- a/tests/plugin_options_test.py
+++ b/tests/plugin_options_test.py
@@ -108,7 +108,7 @@ def test_read_octal_mode_option_invalid(arg):
     ids=_id_func,
 )
 def test_os_allowed_mode(function, arg, allowed_modes):
-    options = flake8.options.manager.OptionManager(version='1.0')
+    options = flake8.options.manager.OptionManager(version='1.0', prog='prog')
     flake8_scs.Plugin.add_options(options)
     values, _ = options.parse_args([f'--os-{function}-mode={arg}'])
     flake8_scs.Plugin.parse_options(values)

--- a/tests/plugin_options_test.py
+++ b/tests/plugin_options_test.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Damien Nguyen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copyright 2022 Damien Nguyen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import ast
+
+import flake8
+import pytest
+
+import flake8_secure_coding_standard as flake8_scs
+
+
+def results(s):
+    return {'{}:{}: {}'.format(*r) for r in flake8_scs.Plugin(ast.parse(s)).run()}
+
+
+# ==============================================================================
+
+_default_modes = list(range(0, flake8_scs._DEFAULT_MAX_MODE + 1))
+
+
+def _id_func(arg):
+    _max_len = 4
+    if arg == _default_modes:
+        return 'default_modes'
+    if isinstance(arg, list) and len(arg) > _max_len:
+        return '[{}...{}]'.format(
+            ','.join(str(val) for val in arg[:_max_len]),
+            ','.join(str(val) for val in arg[-_max_len:]),
+        )
+    return str(arg)
+
+
+# ==============================================================================
+
+
+@pytest.mark.parametrize(
+    'arg, expected',
+    (
+        ('0', 0),
+        ('false', None),
+        ('False', None),
+        ('n', None),
+        ('no', None),
+        ('No', None),
+        ('NO', None),
+        ('y', _default_modes),
+        ('yes', _default_modes),
+        ('Yes', _default_modes),
+        ('YES', _default_modes),
+        ('true', _default_modes),
+        ('True', _default_modes),
+        ('1', 1),
+        ('493', 493),
+        ('0o755', 0o755),
+        ('0o755,', [0o755]),
+        ('0o644, 0o755,', [0o644, 0o755]),
+    ),
+    ids=_id_func,
+)
+def test_read_octal_mode_option(arg, expected):
+    print(f'INFO: expected: {expected}')
+    assert flake8_scs._read_octal_mode_option('test', arg, _default_modes) == expected
+
+
+@pytest.mark.parametrize('arg', ('', ',', ',,', 'nope', 'asd', 'a,', '493, a'))
+def test_read_octal_mode_option_invalid(arg):
+    with pytest.raises(ValueError):
+        flake8_scs._read_octal_mode_option('test', arg, _default_modes)
+
+
+@pytest.mark.parametrize('function', ('open', 'mkdir', 'mkfifo', 'mknod'))
+@pytest.mark.parametrize(
+    'arg, allowed_modes',
+    (
+        ('n', []),
+        ('y', _default_modes),
+        ('0', []),
+        ('0o755', _default_modes),
+        ('0o644, 0o755,', [0o644, 0o755]),
+    ),
+    ids=_id_func,
+)
+def test_os_allowed_mode(function, arg, allowed_modes):
+    options = flake8.options.manager.OptionManager(version='1.0')
+    flake8_scs.Plugin.add_options(options)
+    values, _ = options.parse_args([f'--os-{function}-mode={arg}'])
+    flake8_scs.Plugin.parse_options(values)
+    assert getattr(flake8_scs.Visitor, f'os_{function}_modes_allowed') == allowed_modes

--- a/tests/shelve_open_test.py
+++ b/tests/shelve_open_test.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2021 Damien Nguyen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+
+import pytest
+
+import flake8_secure_coding_standard as flake8_scs
+
+
+def results(s):
+    return {'{}:{}: {}'.format(*r) for r in flake8_scs.Plugin(ast.parse(s)).run()}
+
+
+@pytest.mark.parametrize(
+    's',
+    ('',),
+)
+def test_ok(s):
+    assert results(s) == set()
+
+
+_not_ok = (
+    'shelve.open("file.txt")',
+    'shelve.open(filename)',
+)
+
+
+@pytest.mark.parametrize('s', _not_ok)
+def test_shelve_open_call(s):
+    assert results(s) == {'1:0: ' + flake8_scs.SCS115}
+
+
+@pytest.mark.parametrize('s', _not_ok)
+def test_shelve_open_with(s):
+    assert results(f'with {s} as fd: fd.read()') == {'1:0: ' + flake8_scs.SCS115}
+
+
+@pytest.mark.parametrize('s', ('from shelve import open',))
+def test_shelve_open_importfrom(s):
+    assert results(s) == {'1:0: ' + flake8_scs.SCS115}


### PR DESCRIPTION
Essentially backport of some of the latest functionality also found in [`pylint-secure-cofing-standard`](https://github.com/Takishima/pylint-secure-coding-standard/).

New warnings:

- `SCS112`: Avoid using `os.open()` with unsafe permissions
- `SCS113`: Avoid using `pickle.load()` and `pickle.loads()`
- `SCS114`: Avoid using `marshal.load()` and `marshal.loads()`
- `SCS115`: Avoid using `shelve.open()`
- `SCS116`: Avoid using `os.mkdir` and `os.makedirs` with unsafe file permissions
- `SCS117`: Avoid using `os.mkfifo` with unsafe file permissions
- `SCS118`: Avoid using `os.mknod` with unsafe file permissions
- `SCS119`: Avoid using `os.chmod` with unsafe file permissions (W ^ X for group and others) 